### PR TITLE
Allows users to see their unnamed containers they create in image tab

### DIFF
--- a/src/podmanTreeDataProvider.ts
+++ b/src/podmanTreeDataProvider.ts
@@ -179,15 +179,13 @@ export class PodmanTreeDataProvider implements vscode.TreeDataProvider<PodmanIte
                     .filter((line: string) => line.trim() !== '')
                     .forEach((line: string) => {
                         const [id, repository, tag] = line.split('|');
-                        if (repository !== "<none>" && tag !== "<none>") {
-                            if (!imageMap.has(id)) {
-                                imageMap.set(id, []);
-                            }
-                            imageMap.get(id)!.push(`${repository}:${tag}`);
+                        if (!imageMap.has(id)) {
+                            imageMap.set(id, []);
                         }
+                        imageMap.get(id)!.push(`${repository}:${tag}`);
                     });
 
-                const { stdout: containerStdout } = await execAsync(`${getPodmanPath()} container ls -a --format "{{.ImageID}}"`);
+                const { stdout: containerStdout } = await execAsync(`${getPodmanPath()} container ls -a --format "{{if .ImageID}}{{.ImageID}}{{else}}none{{end}}"`);
                 const usedImageIds = new Set(containerStdout.split('\n').filter((line: string) => line.trim() !== ''));
 
                 return Array.from(imageMap.entries()).map(([id, names]) => {


### PR DESCRIPTION
<img width="405" height="206" alt="image" src="https://github.com/user-attachments/assets/b8ae2807-b578-497e-b47e-909266edbd68" />
 

Allows users to see unnamed containers in their side bar when testing containerfile build scripts. Issue i noticed when doing local development. Originally they would just fail to appear